### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerization.yml
+++ b/.github/workflows/dockerization.yml
@@ -1,4 +1,6 @@
 name: Dockerization of web application
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-Web/security/code-scanning/1](https://github.com/SmartPotTech/SmartPot-Web/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow does not modify repository contents, we can set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the least privilege necessary.

The `permissions` block will be added at the root level, right after the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
