### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Node.js CI
 
 on:
@@ -5,7 +7,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-Web/security/code-scanning/3](https://github.com/SmartPotTech/SmartPot-Web/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file to restrict the `GITHUB_TOKEN` permissions to the least privileges required for the tasks performed. Given the workflow conducts basic CI tasks like installing dependencies, building the project, and running tests, it primarily requires `contents: read`.

Changes will be made to the `.github/workflows/node.js.yml` file. The `permissions` block will be added below the `name` key at the root level of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
